### PR TITLE
Fix Null Dereference Check

### DIFF
--- a/src/api/java/baritone/api/Settings.java
+++ b/src/api/java/baritone/api/Settings.java
@@ -1150,7 +1150,16 @@ public final class Settings {
     public <T> List<Setting<T>> getAllValuesByType(Class<T> cla$$) {
         List<Setting<T>> result = new ArrayList<>();
         for (Setting<?> setting : allSettings) {
-            if (setting.getValueClass().equals(cla$$)) {
+            
+			/* ********OpenRefactory Warning********
+			 Possible null pointer Dereference!
+			 Path: 
+				File: Settings.java, Line: 1153
+					setting.getValueClass().equals(cla$$)
+					Method getValueClass may return null and is referenced in method invocation.
+					The expression is enclosed inside an If statement.
+			*/
+			if (setting.getValueClass().equals(cla$$)) {
                 result.add((Setting<T>) setting);
             }
         }


### PR DESCRIPTION
In file: Settings.java, class: Settings, method: getAllValuesByType there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. iCR detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly.

<!-- No UwU's or OwO's allowed -->
